### PR TITLE
[Common] 엔티티 연관관계 재정리

### DIFF
--- a/src/main/java/com/teamproj/backend/Repository/board/BoardTodayLikeRepository.java
+++ b/src/main/java/com/teamproj/backend/Repository/board/BoardTodayLikeRepository.java
@@ -14,13 +14,5 @@ import java.util.Optional;
 
 
 public interface BoardTodayLikeRepository extends JpaRepository<BoardTodayLike, Long> {
-
-    Page<BoardTodayLike> findAllByBoardCategoryOrderByLikeCountDesc(BoardCategory boardCategory, Pageable pageable);
-
     Optional<BoardTodayLike> findByBoard(Board board);
-
-    @Modifying
-    @Transactional
-    @Query("update BoardTodayLike b set b.likeCount = 0")
-    void resetAll();
 }

--- a/src/main/java/com/teamproj/backend/model/board/Board.java
+++ b/src/main/java/com/teamproj/backend/model/board/Board.java
@@ -1,6 +1,7 @@
 package com.teamproj.backend.model.board;
 
 import com.teamproj.backend.dto.board.BoardUpdate.BoardUpdateRequestDto;
+import com.teamproj.backend.model.Comment;
 import com.teamproj.backend.model.User;
 import com.teamproj.backend.util.Timestamped;
 import lombok.AllArgsConstructor;
@@ -26,7 +27,7 @@ public class Board extends Timestamped {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @ColumnDefault("0")
@@ -46,11 +47,23 @@ public class Board extends Timestamped {
     @Column(columnDefinition = "boolean default true")
     private boolean enabled;
 
-    @OneToMany(mappedBy = "board")
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    private final List<BoardImage> boardImageList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    private final List<Comment> commentList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private final List<BoardHashTag> boardHashTagList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "board")
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private final List<BoardLike> Likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    private final List<BoardTodayLike> boardTodayLikeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    private final List<BoardViewers> boardViewersList = new ArrayList<>();
 
     public void update(BoardUpdateRequestDto boardUpdateRequestDto, String imageUrl) {
         this.title = boardUpdateRequestDto.getTitle();

--- a/src/main/java/com/teamproj/backend/model/board/BoardCategory.java
+++ b/src/main/java/com/teamproj/backend/model/board/BoardCategory.java
@@ -4,8 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -14,4 +18,10 @@ import javax.persistence.Id;
 public class BoardCategory {
     @Id
     private String categoryName;
+
+    @OneToMany(mappedBy = "boardCategory", cascade = CascadeType.ALL)
+    private final List<Board> boardList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "boardCategory", cascade = CascadeType.ALL)
+    private final List<BoardTodayLike> boardTodayLikeList = new ArrayList<>();
 }

--- a/src/main/java/com/teamproj/backend/model/dict/Dict.java
+++ b/src/main/java/com/teamproj/backend/model/dict/Dict.java
@@ -32,10 +32,10 @@ public class Dict extends Timestamped {
     @Column(nullable = false, unique = true)
     private String dictName;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 30)
     private String summary;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @ColumnDefault("0")
@@ -49,4 +49,7 @@ public class Dict extends Timestamped {
 
     @OneToMany(mappedBy = "dict", cascade = CascadeType.ALL)
     private final List<DictLike> dictLikeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "dict", cascade = CascadeType.ALL)
+    private final List<DictViewers> dictViewersList = new ArrayList<>();
 }

--- a/src/main/java/com/teamproj/backend/model/statistics/StatBoardModify.java
+++ b/src/main/java/com/teamproj/backend/model/statistics/StatBoardModify.java
@@ -1,6 +1,5 @@
 package com.teamproj.backend.model.statistics;
 
-import com.teamproj.backend.model.board.Board;
 import com.teamproj.backend.util.Timestamped;
 import lombok.*;
 
@@ -17,6 +16,6 @@ public class StatBoardModify extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long modifyId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Board board;
+    @Column(nullable = false)
+    private Long boardId;
 }

--- a/src/main/java/com/teamproj/backend/util/RedisKey.java
+++ b/src/main/java/com/teamproj/backend/util/RedisKey.java
@@ -1,7 +1,6 @@
 package com.teamproj.backend.util;
 
 public class RedisKey {
-    public static final String CAROUSEL_URL_KEY = "CAROUSEL_URL";
     public static final String TODAY_LIST_KEY = "TODAY_LIST";
     public static final String DICT_RECOMMEND_SEARCH_KEY = "DICT_RECOMMEND_SEARCH";
     public static final String HASHTAG_RECOMMEND_KEY = "HASHTAG_RECOMMEND_KEY";

--- a/src/main/java/com/teamproj/backend/util/Scheduler.java
+++ b/src/main/java/com/teamproj/backend/util/Scheduler.java
@@ -46,7 +46,7 @@ public class Scheduler {
         redisService.setTodayList(TODAY_LIST_KEY, dictService.getTodayMeme(20));
         redisService.setTodayMemeImageList(TODAY_MEME_IMAGE_LIST_KEY, boardService.getTodayImage(5));
         redisService.setTodayBoardList(TODAY_BOARD_LIST_KEY, boardService.getTodayBoard(5));
-        boardTodayLikeRepository.resetAll();
+        boardTodayLikeRepository.deleteAll();
 
         System.out.println("조회수 및 방문자 정보 초기화 .....");
         statService.statVisitorToNumericData(statVisitorRepository.count(), statNumericdataRepository.findByName("VISITOR"));


### PR DESCRIPTION
1. User : 항목이 너무 많아 이후 별도로 처리예정
2. Board : 관련 엔티티 양방향 관계로 전환, content 기본 형식 text로 변경.
3. Dict : 관련 엔티티 양방향으로 전환, content 기본 형식 text로 변경, 한줄요약 최대길이 30으로 제한
4. StatBoardModify : Board와의 관계 제거. boardId만 가지고 있게 될 것임.